### PR TITLE
Add base hardware classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
 
+set(FETCHCONTENT_BASE_DIR ${CMAKE_SOURCE_DIR}/external)
+
 # First fetch the SDL2 library
 FetchContent_Declare(
     SDL2
@@ -13,12 +15,14 @@ FetchContent_Declare(
     GIT_TAG release-2.30.1
 )
 
-set(FETCHCONTENT_BASE_DIR ${CMAKE_SOURCE_DIR}/external)
-
 FetchContent_MakeAvailable(SDL2)
 
-add_executable(emulator src/emulator.cpp)
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
+# Get all .cpp source files
+file(GLOB_RECURSE SRC_FILES ${CMAKE_SOURCE_DIR}/src/*.cpp)
+
+add_executable(emulator ${SRC_FILES})
 
 target_link_libraries(emulator PRIVATE SDL2)
-
 target_include_directories(emulator PRIVATE ${sdl2_SOURCE_DIR}/include)

--- a/include/chip8.hpp
+++ b/include/chip8.hpp
@@ -1,0 +1,29 @@
+#ifndef CHIP8_HPP
+#define CHIP8_HPP
+
+#include <cstdint>
+
+#include "constants.hpp"
+#include "cpu.hpp"
+
+class Chip8
+{
+private:
+    // RAM
+    uint8_t memory[Chip8Specs::MemorySize] {};
+    // Special register used to store memory addresses
+    uint16_t index_register {};
+    uint8_t delay_timer {};
+    uint8_t sound_timer {};
+    uint8_t keypad[Chip8Specs::KeysCount] {};
+    // 1D array representing a 2D screen
+    uint32_t video[Chip8Specs::ScreenWidth * Chip8Specs::ScreeHeight] {};
+    // Operation code, represents an instruction that has
+    // to be executed by the cpu
+    uint16_t opcode {};
+    Cpu cpu {};
+public:
+    Chip8();
+};
+
+#endif

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -5,13 +5,43 @@
 
 namespace Chip8Specs
 {
-    // Hardware defined specifications
-    constexpr int MemorySize    = 4096;
-    constexpr int RegisterCount = 16;
-    constexpr int StackDepth    = 16;
-    constexpr int ScreenWidth   = 64;
-    constexpr int ScreeHeight   = 32;
-    constexpr int KeysCount     = 16;
+    // === Hardware specifications ===
+    constexpr int MemorySize    {4096};
+    constexpr int RegisterCount {16};
+    constexpr int StackDepth    {16};
+    constexpr int ScreenWidth   {64};
+    constexpr int ScreeHeight   {32};
+    constexpr int KeysCount     {16};
+
+    // === Memory Mapping === 
+    constexpr uint16_t FontSetStartAddress {0x050};
+    constexpr uint16_t ProgramStartAddress {0x200};
+
+    // === Pixels ===
+    constexpr uint32_t PixelOn  {0xFFFFFFFF};
+    constexpr uint32_t PixelOff {0x00000000};
+    
+    // === Fontset ===
+    constexpr unsigned int FontsetSize {80};
+    constexpr uint8_t FontSet[FontsetSize]
+    {
+        0xF0, 0x90, 0x90, 0x90, 0xF0, // 0
+        0x20, 0x60, 0x20, 0x20, 0x70, // 1
+        0xF0, 0x10, 0xF0, 0x80, 0xF0, // 2
+        0xF0, 0x10, 0xF0, 0x10, 0xF0, // 3
+        0x90, 0x90, 0xF0, 0x10, 0x10, // 4
+        0xF0, 0x80, 0xF0, 0x10, 0xF0, // 5
+        0xF0, 0x80, 0xF0, 0x90, 0xF0, // 6
+        0xF0, 0x10, 0x20, 0x40, 0x40, // 7
+        0xF0, 0x90, 0xF0, 0x90, 0xF0, // 8
+        0xF0, 0x90, 0xF0, 0x10, 0xF0, // 9
+        0xF0, 0x90, 0xF0, 0x90, 0x90, // A
+        0xE0, 0x90, 0xE0, 0x90, 0xE0, // B
+        0xF0, 0x80, 0x80, 0x80, 0xF0, // C
+        0xE0, 0x90, 0x90, 0x90, 0xE0, // D
+        0xF0, 0x80, 0xF0, 0x80, 0xF0, // E
+        0xF0, 0x80, 0xF0, 0x80, 0x80  // F
+    };
 }
 
 #endif

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -1,0 +1,17 @@
+#ifndef CHIP8_CONSTANTS_HPP
+#define CHIP8_CONSTANTS_HPP
+
+#include <cstdint>
+
+namespace Chip8Specs
+{
+    // Hardware defined specifications
+    constexpr int MemorySize    = 4096;
+    constexpr int RegisterCount = 16;
+    constexpr int StackDepth    = 16;
+    constexpr int ScreenWidth   = 64;
+    constexpr int ScreeHeight   = 32;
+    constexpr int KeysCount     = 16;
+}
+
+#endif

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -1,0 +1,22 @@
+#ifndef CHIP8_CPU_HPP
+#define CHIP8_CPU_HPP
+
+#include <cstdint>
+#include "constants.hpp"
+
+class Cpu {
+private:
+    uint8_t registers[Chip8Specs::RegisterCount] {};
+    // Program counter, holds the address of
+    // the next instruction to execute
+    uint16_t pc {};
+    // keeps track of the order of execution
+    uint16_t stack[Chip8Specs::StackDepth] {};
+    // stack pointer, keeps track of the most
+    // recent value placed in the stack
+    uint8_t sp {};
+public: 
+    Cpu();
+};
+
+#endif

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -1,0 +1,3 @@
+#include "chip8.hpp"
+
+Chip8::Chip8(){};

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1,0 +1,3 @@
+#include "cpu.hpp"
+
+Cpu::Cpu(){};


### PR DESCRIPTION
# Core Chip8 & Cpu classes

## Classes

I added the two most important classes for the emulator.

__Chip8 class contains__:
 - 4 Kb RAM 
 - An index register which is a special register used to store memory addresses
 - A delay timer which will decrement at a rate of 60Hz
 - A sound timer with the same behavior of the delay one
 - A 16 keys keypad (from 0 to F __hexadecimal__)
 - 1D array representing the 64 * 32 monochrome screen
 - The current operation code (opcode), fetched and decoded from the ROM
 - An instance of the __Cpu__ class

__Cpu class contains__:
 - 16 registers (1D array)
 - A program counter, it holds the address of the next instruction to execute
 - A stack to keep track of the order of execution
 - A stack pointer which keeps track of the most recent value placed in the stack

## Constants

To store all the Chip8 specifications, I used a dedicated namespace containing all the constants that I'll be using throughout the implementation. These constants represent hardware specification (e.g : memory size), some memory mapping, on & off pixels values and the fontset.

## CMake

Updated the __CMakeLists.txt__ to include all the header files and all .cpp source files to compilation process.

