### PR TITLE
Rom loading

### DIFF
--- a/include/chip8.hpp
+++ b/include/chip8.hpp
@@ -26,6 +26,8 @@ private:
     Cpu cpu {};
 public:
     Chip8();
+
+    void loadRomIntoMemory(const std::string& filename);
 };
 
 #endif

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -17,6 +17,8 @@ private:
     uint8_t sp {};
 public: 
     Cpu();
+
+    void setPC(uint16_t value);
 };
 
 #endif

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -1,5 +1,8 @@
 #include "chip8.hpp"
 
+#include <fstream>
+#include <stdexcept>
+
 Chip8::Chip8()
 {
     // Load all fonts into memory
@@ -7,4 +10,25 @@ Chip8::Chip8()
     {
         memory[Chip8Specs::FontSetStartAddress + i] = Chip8Specs::FontSet[i];
     }
+}
+
+void Chip8::loadRomIntoMemory(const std::string& filename)
+{
+    // Open the file in binary mode
+    std::ifstream rom(filename, std::ios::binary);
+    if(!rom.is_open())
+        throw std::runtime_error("Error: failed to open ROM : " + filename);
+
+    // Get the size of the rom file
+    rom.seekg(0, std::ios::end);
+    std::streamsize rom_size = static_cast<std::streamsize>(rom.tellg());
+    rom.seekg(0, std::ios::beg);
+
+    // Dump rom content into a buffer
+    char* buffer = new char[rom_size];
+    rom.read(buffer, rom_size);
+
+    // Copy rom content into memory
+    for(std::streamsize i {} ; i < rom_size ; ++i)
+        memory[Chip8Specs::ProgramStartAddress + i] = buffer[i];
 }

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -1,3 +1,10 @@
 #include "chip8.hpp"
 
-Chip8::Chip8(){};
+Chip8::Chip8()
+{
+    // Load all fonts into memory
+    for(uint i {} ; i < Chip8Specs::FontsetSize; ++i)
+    {
+        memory[Chip8Specs::FontSetStartAddress + i] = Chip8Specs::FontSet[i];
+    }
+}

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1,3 +1,9 @@
 #include "cpu.hpp"
 
-Cpu::Cpu(){};
+Cpu::Cpu()
+{
+    // Initialize the programe counter
+    setPC(Chip8Specs::ProgramStartAddress);
+}
+
+void Cpu::setPC(uint16_t value) { pc = value; }


### PR DESCRIPTION
## Load a rom into the emulator

### Chip8 initialization

In the class default constructor, I added the fontset initialization because at some point, the ROMs content will look for it.

### Cpu initialization

Just set the program counter (pc) to the "rom reserved" memory address which is 0x200

### Rom reading and dumping

I added a __loadRomIntoMemory__ member function to the Chip8 class. First, we get the size of the rom file, then all the content is dumped into a temporary buffer. Finally, the buffer is copied into the Chip8 memory.