### PR TITLE
Arithmetic and logical instructions

### DIFF
--- a/include/chip8.hpp
+++ b/include/chip8.hpp
@@ -19,9 +19,6 @@ private:
     uint8_t keypad[Chip8Specs::KeysCount] {};
     // 1D array representing a 2D screen
     uint32_t video[Chip8Specs::ScreenWidth * Chip8Specs::ScreeHeight] {};
-    // Operation code, represents an instruction that has
-    // to be executed by the cpu
-    uint16_t opcode {};
     RandomGenerator random_device {};
     Cpu cpu {};
 public:

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -29,6 +29,9 @@ public:
     void setSystem(Chip8* sys);
     void setPC(uint16_t value);
 
+    uint8_t extractVx(uint16_t mask);
+    uint8_t extractVy(uint16_t mask);
+
     // Instructions
     void opc_8xy0();
     void opc_8xy1();

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include "constants.hpp"
 
+class Chip8;
+
 class Cpu {
 private:
     uint8_t registers[Chip8Specs::RegisterCount] {};
@@ -18,9 +20,13 @@ private:
     // Operation code, represents an instruction that has
     // to be executed by the cpu
     uint16_t opcode {};
+    // Reference to the Chip8 system
+    // used to simplify memory access
+    Chip8* system {nullptr};
 public: 
     Cpu();
 
+    void setSystem(Chip8* sys);
     void setPC(uint16_t value);
 
     // Instructions

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -19,6 +19,18 @@ public:
     Cpu();
 
     void setPC(uint16_t value);
+
+    // Instructions
+    void opc_8xy0();
+    void opc_8xy1();
+    void opc_8xy2();
+    void opc_8xy3();
+    void opc_8xy4();
+    void opc_8xy5();
+    void opc_8xy6();
+    void opc_8xy7();
+    void opc_8xyE();
+
 };
 
 #endif

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -15,6 +15,9 @@ private:
     // stack pointer, keeps track of the most
     // recent value placed in the stack
     uint8_t sp {};
+    // Operation code, represents an instruction that has
+    // to be executed by the cpu
+    uint16_t opcode {};
 public: 
     Cpu();
 

--- a/include/masks.hpp
+++ b/include/masks.hpp
@@ -1,0 +1,18 @@
+#ifndef CHIP8_MASKS_HPP
+#define CHIP8_MASKS_HPP
+
+#include <cstdint>
+
+// Opcode fields extraction masks
+constexpr uint16_t MASK_OPC_VX      { 0x0F00u };
+constexpr uint16_t MASK_OPC_VY      { 0x00F0u };
+constexpr uint16_t MASK_OPC_ADDR    { 0x0FFFu };
+constexpr uint16_t MASK_OPC_BYTE    { 0x00FFu };
+constexpr uint16_t MASK_OPC_NIBBLE  { 0x000Fu };
+
+// 8-bits registers masks
+constexpr uint8_t MASK_LSB          { 0x01u };
+constexpr uint8_t MASK_MSB          { 0x80u };
+constexpr uint8_t MASK_LOWER_8BITS  { 0xFFu };
+
+#endif

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -10,6 +10,9 @@ Chip8::Chip8()
     {
         memory[Chip8Specs::FontSetStartAddress + i] = Chip8Specs::FontSet[i];
     }
+
+    // Bind the system to the cpu
+    cpu.setSystem(this);
 }
 
 void Chip8::loadRomIntoMemory(const std::string& filename)

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -11,6 +11,17 @@ Cpu::Cpu()
 void Cpu::setSystem(Chip8* sys) { system = sys; }
 void Cpu::setPC(uint16_t value) { pc = value; }
 
+// Used to get Register X address value
+uint8_t Cpu::extractVx(uint16_t mask)
+{
+    return (opcode & mask) >> 8u;
+}
+// Used to get Register Y address value
+uint8_t Cpu::extractVy(uint16_t mask)
+{
+    return (opcode & mask) >> 4u;
+}
+
 // === Instructions ===
 
 // Arithmetic and logical instructions
@@ -19,8 +30,8 @@ void Cpu::setPC(uint16_t value) { pc = value; }
 // Set registers: vx = vy
 void Cpu::opc_8xy0() 
 {
-    uint8_t vx = (opcode & MASK_OPC_VX) >> 8u;
-    uint8_t vy = (opcode & MASK_OPC_VY) >> 4u;
+    uint8_t vx {extractVx(MASK_OPC_VX)};
+    uint8_t vy {extractVy(MASK_OPC_VY)};
 
     registers[vx] = registers[vy];
 }

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -62,3 +62,17 @@ void Cpu::opc_8xy3()
 
     registers[vx] ^= registers[vy];
 }
+
+// ADD vx, vy
+void Cpu::opc_8xy4()
+{
+    uint8_t vx {extractVx(MASK_OPC_VX)};
+    uint8_t vy {extractVy(MASK_OPC_VY)};
+
+    uint16_t sum { registers[vx] + registers[vy] };
+
+    // Register vf will carry a flag is the sum overflows 255
+    registers[0xF] = (sum > MASK_LOWER_8BITS) ? 1 : 0;
+
+    registers[vx] = sum & MASK_LOWER_8BITS;
+}

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -94,7 +94,29 @@ void Cpu::opc_8xy6()
 {
     uint8_t vx {extractVx(MASK_OPC_VX)};
 
+    // Save least significant bit 
     registers[0xF] = (registers[vx] & MASK_LSB);
 
     registers[vx] >>= 1;
+}
+
+// SUBN vx, vy
+void Cpu::opc_8xy7()
+{
+    uint8_t vx {extractVx(MASK_OPC_VX)};
+    uint8_t vy {extractVy(MASK_OPC_VY)};
+
+    registers[0xF] = (registers[vy] > registers[vx]) ? 1 : 0;
+
+    registers[vx] = registers[vy] - registers[vx];
+}
+
+// SHL vx
+void Cpu::opc_8xyE()
+{
+    uint8_t vx {extractVx(MASK_OPC_VX)};
+
+    registers[0xF] = (registers[vx] & MASK_MSB) >> 7u;
+
+    registers[vx] <<= 1;
 }

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -76,3 +76,25 @@ void Cpu::opc_8xy4()
 
     registers[vx] = sum & MASK_LOWER_8BITS;
 }
+
+// SUB vx, vy
+void Cpu::opc_8xy5()
+{
+    uint8_t vx {extractVx(MASK_OPC_VX)};
+    uint8_t vy {extractVy(MASK_OPC_VY)};
+
+    // Register vf is set to 1 if vx > vy
+    registers[0xF] = (registers[vx] > registers[vy]) ? 1 : 0;
+
+    registers[vx] -= registers[vy];
+}
+
+// SHR vx
+void Cpu::opc_8xy6()
+{
+    uint8_t vx {extractVx(MASK_OPC_VX)};
+
+    registers[0xF] = (registers[vx] & MASK_LSB);
+
+    registers[vx] >>= 1;
+}

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1,5 +1,6 @@
 #include "cpu.hpp"
 #include "chip8.hpp"
+#include "masks.hpp"
 
 Cpu::Cpu()
 {
@@ -9,3 +10,17 @@ Cpu::Cpu()
 
 void Cpu::setSystem(Chip8* sys) { system = sys; }
 void Cpu::setPC(uint16_t value) { pc = value; }
+
+// === Instructions ===
+
+// Arithmetic and logical instructions
+// between registers x and y
+
+// Set registers: vx = vy
+void Cpu::opc_8xy0() 
+{
+    uint8_t vx = (opcode & MASK_OPC_VX) >> 8u;
+    uint8_t vy = (opcode & MASK_OPC_VY) >> 4u;
+
+    registers[vx] = registers[vy];
+}

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1,9 +1,11 @@
 #include "cpu.hpp"
+#include "chip8.hpp"
 
 Cpu::Cpu()
 {
-    // Initialize the programe counter
+    // Initialize the program counter
     setPC(Chip8Specs::ProgramStartAddress);
 }
 
+void Cpu::setSystem(Chip8* sys) { system = sys; }
 void Cpu::setPC(uint16_t value) { pc = value; }

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -27,11 +27,38 @@ uint8_t Cpu::extractVy(uint16_t mask)
 // Arithmetic and logical instructions
 // between registers x and y
 
-// Set registers: vx = vy
+// LD vx, vy
 void Cpu::opc_8xy0() 
 {
     uint8_t vx {extractVx(MASK_OPC_VX)};
     uint8_t vy {extractVy(MASK_OPC_VY)};
 
     registers[vx] = registers[vy];
+}
+
+// OR vx, vy
+void Cpu::opc_8xy1()
+{
+    uint8_t vx {extractVx(MASK_OPC_VX)};
+    uint8_t vy {extractVy(MASK_OPC_VY)};
+
+    registers[vx] |= registers[vy];
+}
+
+// AND vx, vy
+void Cpu::opc_8xy2()
+{
+    uint8_t vx {extractVx(MASK_OPC_VX)};
+    uint8_t vy {extractVy(MASK_OPC_VY)};
+
+    registers[vx] &= registers[vy];
+}
+
+// XOR vx, vy
+void Cpu::opc_8xy3()
+{
+    uint8_t vx {extractVx(MASK_OPC_VX)};
+    uint8_t vy {extractVy(MASK_OPC_VY)};
+
+    registers[vx] ^= registers[vy];
 }


### PR DESCRIPTION
# Arithmetic and logical instructions

This development adds the 9 __arithmetic__ and __logic__ cpu instructions.

## Instructions

- [x] 8xy0 : LD vx, vy (set vx = vy)
- [x] 8xy1 : OR vx, vy (set vx = vx  OR vy)
- [x] 8xy2 : AND vx, vy (set vx = vx AND vy)
- [x] 8xy3 : XOR vx, vy (set vx = vx XOR vy)
- [x] 8xy4 : ADD vx, vy (set vx = vx + vy)
- [x] 8xy5 : SUB vx, vy (set vx = vx - vy, set vf flag)
- [x] 8xy6 : SHR vx (set vx = vx SHR 1)
- [x] 8xy7 : SUBN vx, vy (set vx = vy - vx, set vf flag)
- [x] 8xyE : SHL vx (set vx = vx SHL 1)