### PR TITLE
Flow control instructions

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -46,6 +46,14 @@ public:
     void opc_00E0();
     void opc_00EE();
 
+    void opc_1nnn();
+    void opc_2nnn();
+    void opc_3xkk();
+    void opc_4xkk();
+    void opc_5xy0();
+    void opc_9xy0();
+    void opc_Bnnn();
+
 };
 
 #endif

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -187,3 +187,23 @@ void Cpu::opc_4xkk()
 
     if(registers[vx] != byte) pc += 2;
 }
+
+// SE vx, vy
+// Skip instruction if vx = vy
+void Cpu::opc_5xy0()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+    uint8_t vy { extractVy(MASK_OPC_VY) };
+
+    if(registers[vx] == registers[vy]) pc += 2;
+}
+
+// SNE vx, vy
+// Skip instruction if vx != vy
+void Cpu::opc_9xy0()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+    uint8_t vy { extractVy(MASK_OPC_VY) };
+
+    if(registers[vx] != registers[vy]) pc += 2;
+}

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -168,3 +168,22 @@ void Cpu::opc_2nnn()
     pc = address;
 }
 
+// SE vx, byte
+// Skip instruction if vx = kk
+void Cpu::opc_3xkk()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+    uint8_t byte { opcode & MASK_OPC_BYTE };
+
+    if(registers[vx] == byte) pc += 2;
+}
+
+// SNE vx, byte
+// Skip instruction if vx != kk
+void Cpu::opc_4xkk()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+    uint8_t byte { opcode & MASK_OPC_BYTE };
+
+    if(registers[vx] != byte) pc += 2;
+}

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -154,14 +154,14 @@ void Cpu::opc_00EE()
 // JP addr
 void Cpu::opc_1nnn()
 {
-    uint16_t address { opcode & MASK_OPC_ADDR };
+    uint16_t address { static_cast<uint16_t>(opcode & MASK_OPC_ADDR) };
     pc = address;
 }
 
 // CALL addr
 void Cpu::opc_2nnn()
 {
-    uint16_t address { opcode & MASK_OPC_ADDR };
+    uint16_t address { static_cast<uint16_t>(opcode & MASK_OPC_ADDR) };
 
     stack[sp] = pc;
     ++sp;
@@ -173,7 +173,7 @@ void Cpu::opc_2nnn()
 void Cpu::opc_3xkk()
 {
     uint8_t vx { extractVx(MASK_OPC_VX) };
-    uint8_t byte { opcode & MASK_OPC_BYTE };
+    uint8_t byte { static_cast<uint8_t>(opcode & MASK_OPC_BYTE) };
 
     if(registers[vx] == byte) pc += 2;
 }
@@ -183,7 +183,7 @@ void Cpu::opc_3xkk()
 void Cpu::opc_4xkk()
 {
     uint8_t vx { extractVx(MASK_OPC_VX) };
-    uint8_t byte { opcode & MASK_OPC_BYTE };
+    uint8_t byte { static_cast<uint8_t>(opcode & MASK_OPC_BYTE) };
 
     if(registers[vx] != byte) pc += 2;
 }

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -145,3 +145,26 @@ void Cpu::opc_00EE()
     pc = stack[--sp];
 }
 
+/*
+    Flow control instructions
+    directly influences program's flow
+    (jump, subroutine call, skip...)
+*/
+
+// JP addr
+void Cpu::opc_1nnn()
+{
+    uint16_t address { opcode & MASK_OPC_ADDR };
+    pc = address;
+}
+
+// CALL addr
+void Cpu::opc_2nnn()
+{
+    uint16_t address { opcode & MASK_OPC_ADDR };
+
+    stack[sp] = pc;
+    ++sp;
+    pc = address;
+}
+


### PR DESCRIPTION
# Control flow instruction

This development adds the 7 following instructions:
- [x] 1nnn - JP addr (jump to address addr)
- [x] 2nnn - CALL addr (call subroutine at address addr)
- [x] 3xkk - SE vx, byte (skip next instruction if vx = byte)
- [x] 4xkk - SNE vx, byte (skip next instruction if vx != byte)
- [x] 5xy0 - SE vx, vy (skip next instruction if vx = vy)
- [x] 9xy0 - SNE vx, vy (skip next instruction if vx != vy)
- [x] Bnnn - JP addr, v0 (jump to address v0 + addr)  