### PR TITLE
Memory registers instructions

### DIFF
--- a/include/chip8.hpp
+++ b/include/chip8.hpp
@@ -28,8 +28,10 @@ public:
 
     uint32_t* getVideo();
     uint16_t getIndexRegister();
+    uint8_t getMemoryAt(uint8_t index);
 
     void setIndexRegister(uint16_t value);
+    void writeMemory(uint8_t index, uint8_t value);
 
 };
 

--- a/include/chip8.hpp
+++ b/include/chip8.hpp
@@ -27,6 +27,9 @@ public:
     void loadRomIntoMemory(const std::string& filename);
 
     uint32_t* getVideo();
+    uint16_t getIndexRegister();
+
+    void setIndexRegister(uint16_t value);
 };
 
 #endif

--- a/include/chip8.hpp
+++ b/include/chip8.hpp
@@ -30,6 +30,7 @@ public:
     uint16_t getIndexRegister();
 
     void setIndexRegister(uint16_t value);
+
 };
 
 #endif

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -54,6 +54,14 @@ public:
     void opc_9xy0();
     void opc_Bnnn();
 
+    void opc_6xkk();
+    void opc_7xkk();
+    void opc_Annn();
+    void opc_Fx1E();
+    void opc_Fx55();
+    void opc_Fx65();
+    void opc_Fx33();
+    
 };
 
 #endif

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -17,6 +17,10 @@ Chip8::Chip8()
 
 // Accessors
 uint32_t* Chip8::getVideo() { return video; }
+uint16_t Chip8::getIndexRegister() { return index_register; }
+
+// Mutators
+void Chip8::setIndexRegister(uint16_t value) { index_register = value; }
 
 void Chip8::loadRomIntoMemory(const std::string& filename)
 {

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -18,9 +18,11 @@ Chip8::Chip8()
 // Accessors
 uint32_t* Chip8::getVideo() { return video; }
 uint16_t Chip8::getIndexRegister() { return index_register; }
+uint8_t Chip8::getMemoryAt(uint8_t index) { return memory[index]; }
 
 // Mutators
 void Chip8::setIndexRegister(uint16_t value) { index_register = value; }
+void Chip8::writeMemory(uint8_t index, uint8_t value) { memory[index] = value; }
 
 void Chip8::loadRomIntoMemory(const std::string& filename)
 {

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -251,3 +251,40 @@ void Cpu::opc_Fx1E()
 
     system->setIndexRegister(system->getIndexRegister() + registers[vx]);
 }
+
+// LD I, vx
+void Cpu::opc_Fx55()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+
+    for(uint8_t i {} ; i < vx ; ++i)
+        system->writeMemory(system->getIndexRegister() + i, registers[i]);
+}
+
+// LD vx, I
+void Cpu::opc_Fx65()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+
+    for(uint8_t i {} ; i < vx ; ++i)
+        registers[i] = system->getMemoryAt(system->getIndexRegister() + i);
+}
+
+// LD B, vx
+void Cpu::opc_Fx33()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+    uint8_t val { registers[vx] };
+
+    uint16_t index { system->getIndexRegister() };
+    // ones digit
+    system->writeMemory(index, val % 10);
+    val /= 10;
+
+    // tens digit
+    system->writeMemory(index + 1, val % 10);
+    val /= 10;
+
+    // hundreds digit
+    system->writeMemory(index + 2, val % 10);
+}

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -235,3 +235,19 @@ void Cpu::opc_7xkk()
 
     registers[vx] += byte;
 }
+
+// LD I, addr
+void Cpu::opc_Annn()
+{
+    uint16_t address { static_cast<uint16_t>(opcode & MASK_OPC_ADDR) };
+
+    system->setIndexRegister(address);
+}
+
+// ADD I, vx
+void Cpu::opc_Fx1E()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+
+    system->setIndexRegister(system->getIndexRegister() + registers[vx]);
+}

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -215,3 +215,23 @@ void Cpu::opc_Bnnn()
 
     pc = registers[0] + address;
 }
+
+// Memory & Registers instructions
+
+// LD vx, byte
+void Cpu::opc_6xkk()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+    uint8_t byte { static_cast<uint8_t>(opcode & MASK_OPC_BYTE) };
+
+    registers[vx] = byte;
+}
+
+// ADD vx, byte
+void Cpu::opc_7xkk()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+    uint8_t byte { static_cast<uint8_t>(opcode & MASK_OPC_BYTE) };
+
+    registers[vx] += byte;
+}


### PR DESCRIPTION
# Memory and registers instructions

This development adds the following 7 cpu instructions 
- [x] 6xkk - Set vx = kk
- [x] 7xkk - Set vx = vx + kk
- [x] Annn -  Set index =  index + vx
- [x] Fx1E - Set index = index + vx
- [x] Fx55 - Store v0 through vx from memory
- [x] Fx65 - Read into v0 through vx from memory
- [x] Fx33 - Store BCD of vx in memory at index i, i +1, i + 2

*index is referring to the index register of the cpu*