### PR TITLE
Miscellaneous instructions

### DIFF
--- a/include/chip8.hpp
+++ b/include/chip8.hpp
@@ -29,9 +29,13 @@ public:
     uint32_t* getVideo();
     uint16_t getIndexRegister();
     uint8_t getMemoryAt(uint8_t index);
+    uint8_t getDelayTimer();
+    uint8_t getSoundTimer();
 
     void setIndexRegister(uint16_t value);
     void writeMemory(uint8_t index, uint8_t value);
+    void setDelayTimer(uint8_t value);
+    void setSoundTimer(uint8_t value);
 
 };
 

--- a/include/chip8.hpp
+++ b/include/chip8.hpp
@@ -27,6 +27,7 @@ public:
     void loadRomIntoMemory(const std::string& filename);
 
     uint32_t* getVideo();
+    uint8_t* getKeypad();
     uint16_t getIndexRegister();
     uint8_t getMemoryAt(uint8_t index);
     uint8_t getDelayTimer();

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -20,9 +20,13 @@ namespace Chip8Specs
     // === Pixels ===
     constexpr uint32_t PixelOn  {0xFFFFFFFF};
     constexpr uint32_t PixelOff {0x00000000};
+
+    // === Sprite ===
+    constexpr int SpriteWidth {8};
     
     // === Fontset ===
-    constexpr unsigned int FontsetSize {80};
+    constexpr unsigned int FontsetSize  {80};
+    constexpr unsigned int FontCharSize {5};
     constexpr uint8_t FontSet[FontsetSize]
     {
         0xF0, 0x90, 0x90, 0x90, 0xF0, // 0

--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -61,6 +61,15 @@ public:
     void opc_Fx55();
     void opc_Fx65();
     void opc_Fx33();
+
+    void opc_Fx07();
+    void opc_Fx15();
+    void opc_Fx18();
+    void opc_Ex9E();
+    void opc_ExA1();
+    void opc_Fx0A();
+    void opc_Dxyn();
+    void opc_Fx29();
     
 };
 

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -17,6 +17,7 @@ Chip8::Chip8()
 
 // Accessors
 uint32_t* Chip8::getVideo() { return video; }
+uint8_t* Chip8::getKeypad() { return keypad; }
 uint16_t Chip8::getIndexRegister() { return index_register; }
 uint8_t Chip8::getMemoryAt(uint8_t index) { return memory[index]; }
 uint8_t Chip8::getDelayTimer() { return delay_timer; }

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -19,10 +19,14 @@ Chip8::Chip8()
 uint32_t* Chip8::getVideo() { return video; }
 uint16_t Chip8::getIndexRegister() { return index_register; }
 uint8_t Chip8::getMemoryAt(uint8_t index) { return memory[index]; }
+uint8_t Chip8::getDelayTimer() { return delay_timer; }
+uint8_t Chip8::getSoundTimer() { return sound_timer; }
 
 // Mutators
 void Chip8::setIndexRegister(uint16_t value) { index_register = value; }
 void Chip8::writeMemory(uint8_t index, uint8_t value) { memory[index] = value; }
+void Chip8::setDelayTimer(uint8_t value) { delay_timer = value; }
+void Chip8::setSoundTimer(uint8_t value) { sound_timer = value; }
 
 void Chip8::loadRomIntoMemory(const std::string& filename)
 {

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -318,3 +318,42 @@ void Cpu::opc_Fx18()
 
     system->setSoundTimer(registers[vx]);
 }
+
+// SKP vx
+void Cpu::opc_Ex9E()
+{
+    uint8_t vx  { extractVx(MASK_OPC_VX) };
+    uint8_t key { registers[vx] };
+
+    if(key < Chip8Specs::KeysCount && system->getKeypad()[key])
+        pc += 2;
+}
+
+// SKNP vx
+void Cpu::opc_ExA1()
+{
+    uint8_t vx  { extractVx(MASK_OPC_VX) };
+    uint8_t key { registers[vx] };
+
+    if(key < Chip8Specs::KeysCount && !system->getKeypad()[key])
+        pc += 2;
+}
+
+// LD vx, K
+// Wait for a key press
+void Cpu::opc_Fx0A()
+{
+    uint8_t vx  { extractVx(MASK_OPC_VX) };
+    uint8_t* keypad { system->getKeypad() };
+
+    for(uint8_t i {} ; i < Chip8Specs::KeysCount ; ++i)
+    {
+        if(keypad[i])
+        {
+            registers[vx] = i;
+            return;
+        }
+    }
+
+    pc -= 2;
+}

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -288,3 +288,33 @@ void Cpu::opc_Fx33()
     // hundreds digit
     system->writeMemory(index + 2, val % 10);
 }
+
+/*
+    System & Peripheral instructions
+    including timers, keypad and sprite
+    manipulation
+*/
+
+// LD vx, DT
+void Cpu::opc_Fx07()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+
+    registers[vx] = system->getDelayTimer();
+}
+
+// LD DT, vx
+void Cpu::opc_Fx15()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+
+    system->setDelayTimer(registers[vx]);
+}
+
+// LD ST, vx
+void Cpu::opc_Fx18()
+{
+    uint8_t vx { extractVx(MASK_OPC_VX) };
+
+    system->setSoundTimer(registers[vx]);
+}


### PR DESCRIPTION
# Miscellaneous instructions

This development adds 8 instructions related to system peripheral such as keypad, screen and timers. There are exactly 8:
- [x] Fx07 - Set vx = delay timer value
- [x] Fx15 - Set delay timer = vx
- [x] Fx18 - Set sound timer = vx
- [x] Ex9E - Skip next instruction if key with the value of vx is pressed
- [x] ExA1 - Skip next instruction if key with the value of vx is NOT pressed
- [x] Fx0A - Wait for a key press and store the value of the key in vx
- [x] Dxyn - Display a sprite of size n starting at memory location I at coordinates vx, vy (vf carry collision flag)
- [x] Fx29 - Set I = location of sprite for digit vx

*I represents the index register*