### PR TITLE
Semantic bug fix

### DIFF
--- a/include/chip8.hpp
+++ b/include/chip8.hpp
@@ -18,7 +18,7 @@ private:
     uint8_t sound_timer {};
     uint8_t keypad[Chip8Specs::KeysCount] {};
     // 1D array representing a 2D screen
-    uint32_t video[Chip8Specs::ScreenWidth * Chip8Specs::ScreeHeight] {};
+    uint32_t video[Chip8Specs::ScreenWidth * Chip8Specs::ScreenHeight] {};
     RandomGenerator random_device {};
     Cpu cpu {};
 public:

--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -10,7 +10,7 @@ namespace Chip8Specs
     constexpr int RegisterCount {16};
     constexpr int StackDepth    {16};
     constexpr int ScreenWidth   {64};
-    constexpr int ScreeHeight   {32};
+    constexpr int ScreenHeight   {32};
     constexpr int KeysCount     {16};
 
     // === Memory Mapping === 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -377,7 +377,7 @@ void Cpu::opc_Dxyn()
     uint8_t sprite_height { static_cast<uint8_t>(opcode & MASK_OPC_NIBBLE) };
 
     // Wrap to avoid overflow screen boundaries
-    uint8_t x_cord = registers[vx] % Chip8Specs::ScreeHeight;
+    uint8_t x_cord = registers[vx] % Chip8Specs::ScreenWidth;
     uint8_t y_cord = registers[vy] % Chip8Specs::ScreeHeight;
 
     registers[0xF] = 0;

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -135,7 +135,7 @@ void Cpu::opc_8xyE()
 void Cpu::opc_00E0()
 {
     uint32_t* video { system->getVideo() };
-    constexpr size_t buffer_size { Chip8Specs::ScreenWidth * Chip8Specs::ScreeHeight };
+    constexpr size_t buffer_size { Chip8Specs::ScreenWidth * Chip8Specs::ScreenHeight };
     std::memset(video, 0, buffer_size * sizeof(uint32_t));
 }
 
@@ -378,7 +378,7 @@ void Cpu::opc_Dxyn()
 
     // Wrap to avoid overflow screen boundaries
     uint8_t x_cord = registers[vx] % Chip8Specs::ScreenWidth;
-    uint8_t y_cord = registers[vy] % Chip8Specs::ScreeHeight;
+    uint8_t y_cord = registers[vy] % Chip8Specs::ScreenHeight;
 
     registers[0xF] = 0;
 


### PR DESCRIPTION
# Fix bug in x coordinate wrapping and constant typo

This development fixes two bugs:
- use the correct constant in x coordinate wrapping formula in instruction Dxyn
- rename constant ScreeHeight to ScreenHeight and change all occurrences