### PR TITLE
Emulation loop

### DIFF
--- a/include/chip8.hpp
+++ b/include/chip8.hpp
@@ -35,7 +35,7 @@ public:
     uint8_t getRandomByte();
 
     void setIndexRegister(uint16_t value);
-    void writeMemory(uint8_t index, uint8_t value);
+    void writeMemory(uint16_t index, uint8_t value);
     void setDelayTimer(uint8_t value);
     void setSoundTimer(uint8_t value);
     void setKeypad(int index, uint8_t value);

--- a/include/chip8.hpp
+++ b/include/chip8.hpp
@@ -29,7 +29,7 @@ public:
     uint32_t* getVideo();
     uint8_t* getKeypad();
     uint16_t getIndexRegister();
-    uint8_t getMemoryAt(uint8_t index);
+    uint8_t getMemoryAt(uint16_t index);
     uint8_t getDelayTimer();
     uint8_t getSoundTimer();
     uint8_t getRandomByte();

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -25,7 +25,7 @@ uint8_t Chip8::getMemoryAt(uint16_t index)
 {
     if (index >= Chip8Specs::MemorySize)
     {
-        std::cerr << "Read out of bounds at address: " << std::hex << index << "\n";
+        std::cout << "Read out of bounds at address: " << std::hex << index << "\n";
         return 0;
     }
 
@@ -38,7 +38,7 @@ uint8_t Chip8::getRandomByte() { return random_device.get(); }
 
 // Mutators
 void Chip8::setIndexRegister(uint16_t value) { index_register = value; }
-void Chip8::writeMemory(uint8_t index, uint8_t value) { memory[index] = value; }
+void Chip8::writeMemory(uint16_t index, uint8_t value) { memory[index] = value; }
 void Chip8::setDelayTimer(uint8_t value) { delay_timer = value; }
 void Chip8::setSoundTimer(uint8_t value) { sound_timer = value; }
 void Chip8::setKeypad(int index, uint8_t value) { keypad[index] = value; }

--- a/src/chip8.cpp
+++ b/src/chip8.cpp
@@ -1,6 +1,7 @@
 #include "chip8.hpp"
 
 #include <fstream>
+#include <iostream>
 #include <stdexcept>
 
 Chip8::Chip8()
@@ -19,7 +20,18 @@ Chip8::Chip8()
 uint32_t* Chip8::getVideo() { return video; }
 uint8_t* Chip8::getKeypad() { return keypad; }
 uint16_t Chip8::getIndexRegister() { return index_register; }
-uint8_t Chip8::getMemoryAt(uint8_t index) { return memory[index]; }
+
+uint8_t Chip8::getMemoryAt(uint16_t index)
+{
+    if (index >= Chip8Specs::MemorySize)
+    {
+        std::cerr << "Read out of bounds at address: " << std::hex << index << "\n";
+        return 0;
+    }
+
+    return memory[index];
+}
+
 uint8_t Chip8::getDelayTimer() { return delay_timer; }
 uint8_t Chip8::getSoundTimer() { return sound_timer; }
 uint8_t Chip8::getRandomByte() { return random_device.get(); }

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -78,10 +78,10 @@ void Cpu::opc_8xy4()
 
     uint16_t sum { static_cast<uint16_t>(registers[vx] + registers[vy]) };
 
-    // Register vf will carry a flag is the sum overflows 255
-    registers[0xF] = (sum > MASK_LOWER_8BITS) ? 1 : 0;
-
     registers[vx] = sum & MASK_LOWER_8BITS;
+
+    // Register vf will carry a flag if the sum overflows 255
+    registers[0xF] = (sum > MASK_LOWER_8BITS) ? 1 : 0;
 }
 
 // SUB vx, vy
@@ -90,21 +90,28 @@ void Cpu::opc_8xy5()
     uint8_t vx {extractVx(MASK_OPC_VX)};
     uint8_t vy {extractVy(MASK_OPC_VY)};
 
-    // Register vf is set to 1 if vx > vy
-    registers[0xF] = (registers[vx] > registers[vy]) ? 1 : 0;
+    uint8_t tmp { registers[vx] };
 
     registers[vx] -= registers[vy];
+
+    // Register vf is set to 1 if vx > vy
+    registers[0xF] = (tmp >= registers[vy]) ? 1 : 0;
 }
 
 // SHR vx
 void Cpu::opc_8xy6()
 {
     uint8_t vx {extractVx(MASK_OPC_VX)};
+    uint8_t vy {extractVy(MASK_OPC_VY)};
+
+    uint8_t old_vx { registers[vx] };
+
+    uint8_t shifted_vy { registers[vy] >>= 1 };
+
+    registers[vx] = shifted_vy;
 
     // Save least significant bit 
-    registers[0xF] = (registers[vx] & MASK_LSB);
-
-    registers[vx] >>= 1;
+    registers[0xF] = (old_vx & MASK_LSB);
 }
 
 // SUBN vx, vy
@@ -113,19 +120,24 @@ void Cpu::opc_8xy7()
     uint8_t vx {extractVx(MASK_OPC_VX)};
     uint8_t vy {extractVy(MASK_OPC_VY)};
 
-    registers[0xF] = (registers[vy] > registers[vx]) ? 1 : 0;
-
     registers[vx] = registers[vy] - registers[vx];
+
+    registers[0xF] = (registers[vy] >= registers[vx]) ? 1 : 0;
 }
 
 // SHL vx
 void Cpu::opc_8xyE()
 {
     uint8_t vx {extractVx(MASK_OPC_VX)};
+    uint8_t vy {extractVy(MASK_OPC_VY)};
 
-    registers[0xF] = (registers[vx] & MASK_MSB) >> 7u;
+    uint8_t old_vx { registers[vx] };
 
-    registers[vx] <<= 1;
+    uint8_t shifted_vy { registers[vy] <<= 1 };
+
+    registers[vx] = shifted_vy;
+
+    registers[0xF] = (old_vx & MASK_MSB) >> 7u;
 }
 
 // Machine instructions

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -430,7 +430,10 @@ void Cpu::opc_Dxyn()
         {
             uint8_t sprite_pixel = sprite_byte & (0x80u >> col) ;
             uint32_t* video { system->getVideo() };
-            uint32_t* screen_pixel { &video[(y_cord + row) * Chip8Specs::ScreenWidth + (x_cord + col)] };
+            uint32_t* screen_pixel { &video[
+                ((y_cord + row) % Chip8Specs::ScreenHeight) * Chip8Specs::ScreenWidth +
+                ((x_cord + col) % Chip8Specs::ScreenWidth)
+            ]};
 
             if(sprite_pixel)
             {

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -3,11 +3,13 @@
 #include "masks.hpp"
 
 #include <cstring>
+#include <iostream>
 
 Cpu::Cpu()
 {
     // Initialize the program counter
     setPC(Chip8Specs::ProgramStartAddress);
+    dispatchInstructions();
 }
 
 void Cpu::setSystem(Chip8* sys) { system = sys; }
@@ -503,11 +505,16 @@ void Cpu::Cycle()
 {
     // Fetch opcode from memory
     opcode = (system->getMemoryAt(pc) << 8u) | system->getMemoryAt(pc + 1);
-
     pc += 2;
 
     // Decode the instruction
-    uint8_t instruction_id = (opcode & 0xF000u) >> 12;
+    uint8_t instruction_id = (opcode & 0xF000u) >> 12u;
+
+    if (table[instruction_id] == nullptr) {
+        std::cerr << "Unknown instruction ID: " << std::hex << instruction_id
+                  << " from opcode "            << std::hex << opcode << '\n';
+        return;
+    }
 
     // Execute
     (this->*table[instruction_id])();

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -274,8 +274,10 @@ void Cpu::opc_Fx55()
 {
     uint8_t vx { extractVx(MASK_OPC_VX) };
 
-    for(uint8_t i {} ; i < vx ; ++i)
+    for(uint8_t i {} ; i <= vx ; ++i)
         system->writeMemory(system->getIndexRegister() + i, registers[i]);
+
+    system->setIndexRegister(system->getIndexRegister() + vx + 1);
 }
 
 // LD vx, I
@@ -283,8 +285,10 @@ void Cpu::opc_Fx65()
 {
     uint8_t vx { extractVx(MASK_OPC_VX) };
 
-    for(uint8_t i {} ; i < vx ; ++i)
+    for(uint8_t i {} ; i <= vx ; ++i)
         registers[i] = system->getMemoryAt(system->getIndexRegister() + i);
+
+    system->setIndexRegister(system->getIndexRegister() + vx + 1);
 }
 
 // LD B, vx
@@ -295,7 +299,7 @@ void Cpu::opc_Fx33()
 
     uint16_t index { system->getIndexRegister() };
     // ones digit
-    system->writeMemory(index, val % 10);
+    system->writeMemory(index + 2, val % 10);
     val /= 10;
 
     // tens digit
@@ -303,7 +307,7 @@ void Cpu::opc_Fx33()
     val /= 10;
 
     // hundreds digit
-    system->writeMemory(index + 2, val % 10);
+    system->writeMemory(index, val % 10);
 }
 
 // RND vx, byte

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -47,6 +47,7 @@ void Cpu::opc_8xy1()
     uint8_t vy {extractVy(MASK_OPC_VY)};
 
     registers[vx] |= registers[vy];
+    registers[0xF] = 0;
 }
 
 // AND vx, vy
@@ -56,6 +57,7 @@ void Cpu::opc_8xy2()
     uint8_t vy {extractVy(MASK_OPC_VY)};
 
     registers[vx] &= registers[vy];
+    registers[0xF] = 0;
 }
 
 // XOR vx, vy
@@ -65,6 +67,7 @@ void Cpu::opc_8xy3()
     uint8_t vy {extractVy(MASK_OPC_VY)};
 
     registers[vx] ^= registers[vy];
+    registers[0xF] = 0;
 }
 
 // ADD vx, vy

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -1,7 +1,57 @@
-#include <SDL.h>
+#include <chrono>
+#include <iomanip>
 #include <iostream>
 
-int main()
+#include "chip8.hpp"
+#include "cpu.hpp"
+#include "sdl_interface.hpp"
+#include "constants.hpp"
+
+int main(int argc, char* argv[])
 {
+    if (argc != 4)
+	{
+		std::cerr << "Emulator Usage: " << argv[0] << " <ROM> <Scale> <Delay>" << '\n';
+		std::exit(EXIT_FAILURE);
+	}
+
+	char* romFilename       { argv[1] };
+	int video_scale_coeff   { std::stoi(argv[2]) };
+	int cycle_delay         { std::stoi(argv[3]) };
+
+    Chip8 chip8 {};
+
+    try {
+        chip8.loadRomIntoMemory(romFilename);
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << "\n";
+        return EXIT_FAILURE;
+    }
+    SdlInterface interface("Test", Chip8Specs::ScreenWidth * video_scale_coeff, Chip8Specs::ScreenHeight * video_scale_coeff, Chip8Specs::ScreenWidth, Chip8Specs::ScreenHeight, &chip8);
+
+    int pitch { static_cast<int>(sizeof(chip8.getVideo()[0]) * Chip8Specs::ScreenWidth) };
+
+	auto previous_cycle_time { std::chrono::high_resolution_clock::now() };
+	bool quit { false };
+
+    while (!quit)
+	{
+		quit = interface.HandleKeyInput();
+
+		auto current_time { std::chrono::high_resolution_clock::now() };
+		float delta_time {
+            std::chrono::duration<float, std::chrono::milliseconds::period>(current_time - previous_cycle_time).count()
+        };
+
+		if (delta_time > cycle_delay)
+		{
+			previous_cycle_time = current_time;
+
+			chip8.Cycle();
+
+			interface.Update(pitch);
+		}
+	}
+
     return 0;
 }


### PR DESCRIPTION
# Emulation

This is the last core chip8 emulator development.

## Error fixing

When I was writing code, I found a lot of small mistakes, bugs and oversights. 
Those errors included:
- wrong memory index causing out of bounds read
- cpu instructions dispatching function forgotten
- flag register badly set
- wrong memory storing and reading instructions

## Emulation loop

I added the base emulation loop and will probably be modified later but for now it works like this.

User executes the binary with 3 arguments:
- Rom path
- Scale coefficient to play on wider screens
- Delay used for timer (influences frame per seconds)

Then ROM content is loaded into memory and the loop start executing. One cycle is executed every `delay` second.