### PR TITLE
Pixels color

### DIFF
--- a/include/constants.hpp
+++ b/include/constants.hpp
@@ -22,6 +22,8 @@ namespace Chip8Specs
     // === Pixels ===
     constexpr uint32_t PixelOn  {0xFFFFFFFF};
     constexpr uint32_t PixelOff {0x00000000};
+    constexpr uint32_t ColorOn  {0xFF666600};
+    constexpr uint32_t ColorOff {0xFFFFFFFF};
 
     // === Sprite ===
     constexpr int SpriteWidth {8};

--- a/src/sdl_interface.cpp
+++ b/src/sdl_interface.cpp
@@ -56,7 +56,14 @@ bool SdlInterface::HandleKeyInput()
 
 void SdlInterface::Update(int pitch)
 {
-    SDL_UpdateTexture(texture, nullptr, system->getVideo(), pitch);
+    uint32_t frame_buffer[Chip8Specs::ScreenWidth * Chip8Specs::ScreenHeight];
+
+    uint32_t* video { system->getVideo() };
+
+    for(int i {} ; i < Chip8Specs::ScreenWidth * Chip8Specs::ScreenHeight ; ++i)
+        frame_buffer[i] = (video[i] ? Chip8Specs::ColorOn : Chip8Specs::ColorOff);
+
+    SDL_UpdateTexture(texture, nullptr, frame_buffer, pitch);
     SDL_RenderClear(renderer);
     SDL_RenderCopy(renderer, texture, nullptr, nullptr);
     SDL_RenderPresent(renderer);


### PR DESCRIPTION
# Custom pixel color

I added custom colors for ON & OFF pixels because I got bored of the classical black & white layout.

In the update method, we are now iterating through the video array and filling a frame buffer with the custom color value. We can do this with a simple check on the original video buffer to see if the pixel is ON or OFF.