### PR TITLE
Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Ignore all build files
+build/
+external/sdl2-subbuild/
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Path to the ROM
+ROM_PATH=roms/pong.ch8
+# Scale factor to play on a wider screen
+SCALE=10
+# Delay between cpu cycles
+DELAY=1

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@
 # Build folder
 /build/
 /external/
+
+# Environment
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:25.04
+
+RUN apt-get update && apt-get install -y \
+    cmake \
+    make \
+    g++ \
+    git \
+    libsdl2-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY . .
+
+RUN mkdir -p build && cd build && cmake .. && make
+
+ENTRYPOINT [ "./build/emulator" ]

--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ First clone this repository
 git clone <repository_url>
 ```
 
-### Build and Run
+## Build and Run
 
-You can then create a build folder and execute the following commands:
+### Classical way (local)
+
+#### Build
+
+You can create a `build` folder and execute the following commands:
 
 ```bash
 mkdir build
@@ -20,8 +24,63 @@ cmake ..
 make
 ```
 
-Finally, you just have to run the generated executable
+The generated executable is called `emulator`.
+
+#### Run
+
+There are 3 options required to correctly run the emulator:
+ - ROM path
+ - Resolution scale factor
+ - CPU cycle delay
+
+Here's an example command to properly use the binary:
 
 ```bash
-./emulator
+./emulator roms/pong.ch8 10 1
+```
+
+### Docker container
+
+You can build the project's container by running this command:
+
+```bash
+docker build -t chip8pp .
+```
+
+Then, two options can be considered to run the container.
+
+#### Docker compose & .env file
+
+To run the container this way, you have to create a __.env__ file following the `.env.example` template. 
+
+##### Granting access to X11 (Linux only)
+
+On Linux, you need to grant access to the X11 server for Docker, because SDL needs to open a graphical window.
+If you choose to use the Docker Compose command, you must first run the following command:
+
+```bash
+xhost +local:docker
+```
+>Note: This is required only if you are using the X11 display server.
+On systems running Wayland (e.g., recent Ubuntu, Fedora), additional configuration may be needed, as xhost might not be sufficient.
+
+Then just run the following command:
+
+```bash
+docker compose run --rm chip8pp
+```
+
+Note that you can also specify one or more arguments to override the values in `.env`.
+Here's an example
+
+```bash
+ROM_PATH=roms/superpong.ch8 docker compose run --rm chip8pp
+```
+
+#### Bash script
+
+There's also a __script__ that you can use to run the container. It requires 3 arguments (same as before) to run properly. You can use it like this:
+
+```bash
+./run_container.sh -r roms/pong.ch8 -s 10 -d 1
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  chip8pp:
+    image: chip8pp:latest
+    environment:
+      - DISPLAY=$DISPLAY
+      - ROM_PATH=${ROM_PATH}
+      - SCALE=${SCALE}
+      - DELAY=${DELAY}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    entrypoint: ["./build/emulator"]
+    command: ["${ROM_PATH}", "${SCALE}", "${DELAY}"]
+    stdin_open: true
+    tty: true

--- a/run_container.sh
+++ b/run_container.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+function help_msg() 
+{
+    echo "Usage: $0 [OPTIONS] ROM_PATH [SCALE] [DELAY]"
+    echo
+    echo "Options:"
+    echo "  -h, --help        Prints this help message"
+    echo "  -r, --rom         ROM path"
+    echo "  -s, --scale       Resolution scale (10 by default)."
+    echo "  -d, --delay       Cycle delay (1 by default)."
+    echo
+    echo "Example : $0 -r roms/pong.ch8 -s 15 -d 2"
+}
+
+ROM_PATH=""
+SCALE=10
+DELAY=1
+
+# Arguments parsing
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            help_msg
+            exit 0
+            ;;
+        -r|--rom)
+            ROM_PATH=$2
+            shift
+            ;;
+        -s|--scale)
+            SCALE=$2
+            shift
+            ;;
+        -d|--delay)
+            DELAY=$2
+            shift
+            ;;
+        *)
+            echo "Invalid option: $1"
+            help_msg
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ -z "$ROM_PATH" ]; then
+    echo "Error: ROM path should be specified"
+    help_msg
+    exit 1
+fi
+
+# Check if xhost is activated
+# Container needs it to run SDL in host
+# graphical environment
+if ! xhost | grep -q "local:docker"; then
+    xhost +local:docker
+fi
+
+docker run --rm -it -e DISPLAY=$DISPLAY \
+-v /tmp/.X11-unix:/tmp/.X11-unix chip8pp:latest $ROM_PATH $SCALE $DELAY

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -27,7 +27,7 @@ int main(int argc, char* argv[])
         std::cerr << e.what() << "\n";
         return EXIT_FAILURE;
     }
-    SdlInterface interface("Test", Chip8Specs::ScreenWidth * video_scale_coeff, Chip8Specs::ScreenHeight * video_scale_coeff, Chip8Specs::ScreenWidth, Chip8Specs::ScreenHeight, &chip8);
+    SdlInterface interface("Chip8pp", Chip8Specs::ScreenWidth * video_scale_coeff, Chip8Specs::ScreenHeight * video_scale_coeff, Chip8Specs::ScreenWidth, Chip8Specs::ScreenHeight, &chip8);
 
     int pitch { static_cast<int>(sizeof(chip8.getVideo()[0]) * Chip8Specs::ScreenWidth) };
 


### PR DESCRIPTION
# Container

Added the possibility to run the emulator on a __docker container__. 

The image is built with a docker file then the user can choose to run the container through the `docker compose` utility or the `run_container.sh`.

All is detailed in the `README.md` file.