### PR TITLE
Sound handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13)
+cmake_policy(SET CMP0077 NEW)
+
 project(chip-8pp)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -8,7 +10,11 @@ include(FetchContent)
 
 set(FETCHCONTENT_BASE_DIR ${CMAKE_SOURCE_DIR}/external)
 
-# First fetch the SDL2 library
+set(SDL_AUDIO ON CACHE BOOL "" FORCE)
+set(SDL_ALSA ON CACHE BOOL "" FORCE)
+set(SDL_PULSEAUDIO ON CACHE BOOL "" FORCE)
+set(SDL_PIPEWIRE ON CACHE BOOL "" FORCE)
+
 FetchContent_Declare(
     SDL2
     GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
@@ -19,7 +25,6 @@ FetchContent_MakeAvailable(SDL2)
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
-# Get all .cpp source files
 file(GLOB_RECURSE SRC_FILES ${CMAKE_SOURCE_DIR}/src/*.cpp)
 
 add_executable(emulator ${SRC_FILES})

--- a/include/sdl_interface.hpp
+++ b/include/sdl_interface.hpp
@@ -12,6 +12,10 @@ private:
     SDL_Texture* texture    {nullptr};
     Chip8* system           {nullptr};
 
+    SDL_AudioDeviceID audio_device  {};
+    uint8_t* audio_buffer           {};
+    uint32_t audio_length           {};
+
 
 public:
     SdlInterface(const char* window_title,

--- a/include/sdl_interface.hpp
+++ b/include/sdl_interface.hpp
@@ -25,6 +25,8 @@ public:
 
     bool HandleKeyInput();
     void Update(int pitch);
+    void InitSound();
+    void PlaySound();
 };
 
 #endif

--- a/include/sound_related.hpp
+++ b/include/sound_related.hpp
@@ -1,0 +1,19 @@
+#ifndef SOUND_SPECS_HPP
+#define SOUND_SPECS_HPP
+
+#include <SDL.h>
+
+namespace SoundSpecs 
+{
+    // frequency in Hz
+    constexpr int device_frequency { 44100 };
+    // 8 unsigned bits audio
+    SDL_AudioFormat device_format { AUDIO_U8 };
+    // audio buffer size
+    constexpr int device_samples { 1024 };
+
+    constexpr int sound_frequency { 1000 };
+    constexpr int sound_duration_ms { 100 }; 
+}
+
+#endif

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -49,6 +49,8 @@ int main(int argc, char* argv[])
 
 			chip8.Cycle();
 
+            if(chip8.getSoundTimer() > 0) interface.PlaySound();
+
 			interface.Update(pitch);
 		}
 	}

--- a/src/sdl_interface.cpp
+++ b/src/sdl_interface.cpp
@@ -112,3 +112,10 @@ void SdlInterface::InitSound()
     for (int i = 0 ; i < sample_count ; ++i)
         audio_buffer[i] = (i / half_period) % 2 == 0 ? 255 : 0;
 }
+
+void SdlInterface::PlaySound()
+{
+    SDL_ClearQueuedAudio(audio_device);
+    SDL_QueueAudio(audio_device, audio_buffer, audio_length);
+    SDL_PauseAudioDevice(audio_device, 0);
+}

--- a/src/sdl_interface.cpp
+++ b/src/sdl_interface.cpp
@@ -1,11 +1,13 @@
 #include "sdl_interface.hpp"
 #include "constants.hpp"
 
+#include <iostream>
+
 SdlInterface::SdlInterface(const char* window_title,
     int window_width, int window_height,
     int texture_width, int texture_height, Chip8* system) : system {system}
 {
-    SDL_Init(SDL_INIT_VIDEO);
+    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO);
 
     window = SDL_CreateWindow(window_title, 0, 0, window_width, window_height, SDL_WINDOW_SHOWN);
 
@@ -13,6 +15,8 @@ SdlInterface::SdlInterface(const char* window_title,
 
     texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, 
         texture_width, texture_height);
+
+    InitSound();
 }
 
 SdlInterface::~SdlInterface()
@@ -20,6 +24,9 @@ SdlInterface::~SdlInterface()
     SDL_DestroyTexture(texture);
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(window);
+    SDL_CloseAudioDevice(audio_device);
+    delete[] audio_buffer;
+
     SDL_Quit();
 }
 


### PR DESCRIPTION
# Emulator Sound Handling

I added the interface between SDL audio device and the emulator. It is the basic SDL audio configuration. 

## CMake configuration

To make the audio backend available, I included __ALSA__, __pipewire__ and __pulseaudio__ backend compilation in the `CMakeLists.txt`

## SdlInterface class

I added sound related attributes to the class, initialized audio in class constructor and memory free in destructor.
Then, a function that generates a square wave has been written. This way it produces a sound with a fixed amplitude on high and low profile.

## Main emulation loop

Finally, in the main loop, I added a check on the __sound timer__  to call the function that actually plays a sound.