### PR TITLE
Docker sound handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     g++ \
     git \
     libsdl2-dev \
+    libpulse0 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,13 @@ services:
       - ROM_PATH=${ROM_PATH}
       - SCALE=${SCALE}
       - DELAY=${DELAY}
+      - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
+      - ${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native
+      - ~/.config/pulse/cookie:/root/.config/pulse/cookie
+    devices:
+      - /dev/snd
     entrypoint: ["./build/emulator"]
     command: ["${ROM_PATH}", "${SCALE}", "${DELAY}"]
     stdin_open: true

--- a/run_container.sh
+++ b/run_container.sh
@@ -58,5 +58,11 @@ if ! xhost | grep -q "local:docker"; then
     xhost +local:docker
 fi
 
-docker run --rm -it -e DISPLAY=$DISPLAY \
--v /tmp/.X11-unix:/tmp/.X11-unix chip8pp:latest $ROM_PATH $SCALE $DELAY
+docker run --rm \
+    -e DISPLAY=$DISPLAY \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -e PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native \
+    -v ${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native \
+    -v ~/.config/pulse/cookie:/root/.config/pulse/cookie \
+    --device /dev/snd \
+    chip8pp:latest $ROM_PATH $SCALE $DELAY


### PR DESCRIPTION
# Allow emulator to play sound in the docker container

To make this possible, I first included the installation of _libpulse0_ in the `Dockerfile`. This way pulse audio is installed in the container.

## `run_container.sh` script

Then I just edited the `docker run` command. Added volume mounting for pulse audio server and authentication.

## `docker-compose.yml` file

It's pretty much the same adds. The pulse server running path is declared and volumes are mounted.