### PR TITLE
Sound mute

### DIFF
--- a/include/sdl_interface.hpp
+++ b/include/sdl_interface.hpp
@@ -16,6 +16,7 @@ private:
     uint8_t* audio_buffer           {};
     uint32_t audio_length           {};
 
+    bool is_muted {false};
 
 public:
     SdlInterface(const char* window_title,

--- a/src/sdl_interface.cpp
+++ b/src/sdl_interface.cpp
@@ -39,6 +39,10 @@ bool SdlInterface::HandleKeyInput()
 
     while(SDL_PollEvent(&event))
     {
+
+        if(event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_m)
+            is_muted = !is_muted;
+
         switch(event.type)
         {
         case SDL_QUIT:
@@ -110,11 +114,14 @@ void SdlInterface::InitSound()
     int half_period = spec.freq / (2 * frequency);
     // Square wave: 255 (high), 0 (low)
     for (int i = 0 ; i < sample_count ; ++i)
-        audio_buffer[i] = (i / half_period) % 2 == 0 ? 255 : 0;
+        audio_buffer[i] = (i / half_period) % 2 == 0 ? 5 : 0;
 }
 
 void SdlInterface::PlaySound()
 {
+    if(is_muted)
+        return;
+
     SDL_ClearQueuedAudio(audio_device);
     SDL_QueueAudio(audio_device, audio_buffer, audio_length);
     SDL_PauseAudioDevice(audio_device, 0);


### PR DESCRIPTION
# Sound mute mode

Decided to do a mute mode to increase accessibility and because one might want to play without sound.

## `HandleKeyInput` function

This function has been a bit modified to check if key __m__ is pressed. Like that it can toggle the new `is_muted` attribute of `SdlInterface` class.

## `PlaySound` function

Just added a check to see whether mute mode is on or not. If it is then the function will do nothing and no sound will be hear.