### PR TITLE
Container size optimisation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
-# Path to the ROM
+# ROM's related informations
 ROM_PATH=roms/pong.ch8
+ROM_FILENAME=pong.ch8
+ROM_DIRNAME=roms
+ROM_DIR_PATH=./${ROM_DIRNAME}
 # Scale factor to play on a wider screen
 SCALE=10
 # Delay between cpu cycles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:25.04
+# Build stage
+FROM debian:bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y \
     cmake \
@@ -14,5 +15,25 @@ WORKDIR /app
 COPY . .
 
 RUN mkdir -p build && cd build && cmake .. && make
+
+# Final small image
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    libsdl2-2.0-0 \
+    libx11-6 \
+    libxext6 \
+    libxrandr2 \
+    libxrender1 \
+    libxfixes3 \
+    libxcursor1 \
+    libxi6 \
+    libgl1 \
+    libpulse0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /app/build ./build
 
 ENTRYPOINT [ "./build/emulator" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@ services:
   chip8pp:
     image: chip8pp:latest
     environment:
-      - DISPLAY=$DISPLAY
-      - ROM_PATH=${ROM_PATH}
+      - DISPLAY=${DISPLAY}
       - SCALE=${SCALE}
       - DELAY=${DELAY}
       - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
@@ -11,9 +10,10 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native
       - ~/.config/pulse/cookie:/root/.config/pulse/cookie
+      - ${ROM_DIR_PATH}:/roms
     devices:
       - /dev/snd
     entrypoint: ["./build/emulator"]
-    command: ["${ROM_PATH}", "${SCALE}", "${DELAY}"]
+    command: ["/${ROM_DIRNAME}/${ROM_FILENAME}", "${SCALE}", "${DELAY}"]
     stdin_open: true
     tty: true

--- a/run_container.sh
+++ b/run_container.sh
@@ -51,6 +51,10 @@ if [ -z "$ROM_PATH" ]; then
     exit 1
 fi
 
+ROM_PATH_ABS=$(realpath "$ROM_PATH")
+ROM_DIR=$(dirname "$ROM_PATH_ABS")
+ROM_FILENAME=$(basename "$ROM_PATH_ABS")
+
 # Check if xhost is activated
 # Container needs it to run SDL in host
 # graphical environment
@@ -65,4 +69,5 @@ docker run --rm \
     -v ${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native \
     -v ~/.config/pulse/cookie:/root/.config/pulse/cookie \
     --device /dev/snd \
-    chip8pp:latest $ROM_PATH $SCALE $DELAY
+    -v "$ROM_DIR":/roms \
+    chip8pp:latest "/roms/$ROM_FILENAME" "$SCALE" "$DELAY"


### PR DESCRIPTION
# Container optimization

Found that the container size was very big for its use : __~1.8 GB__.
With this development the container now weights __~325 MB__

To make this possible, several things have been added:
 - [x] A build stage in the Dockerfile, using the debian bookworm slim image
 - [x] A dynamic rom mounting in the container execution script
 - [x] Same as previous but in the docker-compose file